### PR TITLE
fix: escape value in terraform.tfvars

### DIFF
--- a/writers.go
+++ b/writers.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -94,7 +95,7 @@ func (w *TfVarFileWriter) Write(resName, ssmName, varName string) error {
 		varValue = *param.Parameter.Value
 	}
 
-	fmt.Fprintf(w.out, `%s = "%s"`, varName, varValue)
+	fmt.Fprintf(w.out, `%s = %s`, varName, strconv.Quote(varValue))
 	fmt.Fprintln(w.out)
 	return nil
 }


### PR DESCRIPTION
terraform.tfvars 中类似 `\\n` 这样的值同步回来后会变成 `\n`